### PR TITLE
Adding tooltipContainer and useFixedPosition properties

### DIFF
--- a/src/custom-elements/cps-tooltip/Readme.md
+++ b/src/custom-elements/cps-tooltip/Readme.md
@@ -15,6 +15,8 @@ The `<cps-tooltip>` dom node is `display: inline`.
 Properties are good for both initial configuration and for all subsequent changes to the DOM element.
 - `html` (required): A string of html to show in the tooltip.
 - `delayTime` (optional): The number of milliseconds to wait before showing the tooltip.
+- `useFixedPosition` (optional): A boolean that determines whether the tooltip should be fixed positioned or not. Defaults to false.
+- `tooltipContainer` (optional): The container DOM element to put the tooltip element in. Defaults to the nearest positioned ancestor of the `<cps-tooltip>` element.
 
 ## Attributes
 Attributes are good for initial configuration. If an attribute is changed, the corresponding property will be updated.

--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -18,17 +18,20 @@ class CpsTooltip extends Component {
 		this.props.customElement.classList.add(styles.inlineBlock)
 	}
 	render() {
-		if (!this.tooltipContainer && this.state.renderTooltip) {
-			this.tooltipContainer = document.createElement('div');
-			this.tooltipContainer.classList.add(styles.tooltipContainer);
+		const offsetParent = $(this.props.customElement).offsetParent()[0];
+		if (!this.tooltipParent && this.state.renderTooltip) {
+			this.tooltipParent = document.createElement('div');
+			this.tooltipParent.classList.add(styles.tooltipContainer);
 			// Put the tooltip element into the nearest positioned ancestor, so that offsetTop works.
-			this.parentElement = $(this.props.customElement).offsetParent()[0];
-			this.parentElement.appendChild(this.tooltipContainer);
+			this.parentElement = this.props.tooltipContainer || offsetParent
+			this.parentElement.appendChild(this.tooltipParent);
 		}
 
-		const props = {...this.props, tooltipShown: this.tooltipShown};
+		const startingLeft = this.props.tooltipContainer ? offsetParent.getBoundingClientRect().left : 0;
+		const startingTop = this.props.tooltipContainer ? offsetParent.getBoundingClientRect().top : 0;
+		const props = {...this.props, tooltipShown: this.tooltipShown, startingLeft, startingTop};
 		const thingToRender = this.state.renderTooltip ? h(Tooltip, props) : '';
-		this.preactTooltip = preact.render(thingToRender, this.tooltipContainer, this.preactTooltip);
+		this.preactTooltip = preact.render(thingToRender, this.tooltipParent, this.preactTooltip);
 
 		// Don't return anything, we don't care about innerHTML of the custom element
 		return <div style={{height: 0, width: 0}} />;
@@ -36,7 +39,7 @@ class CpsTooltip extends Component {
 	componentWillUnmount() {
 		this.deleteTooltipElement();
 		if (this.parentElement) {
-			preact.render('', this.parentElement, this.tooltipContainer);
+			preact.render('', this.parentElement, this.tooltipParent);
 			delete this.parentElement;
 		}
 	}
@@ -56,9 +59,9 @@ class CpsTooltip extends Component {
 		this.props.customElement.dispatchEvent(new CustomEvent('cps-tooltip:hidden'));
 	}
 	deleteTooltipElement = () => {
-		if (this.tooltipContainer) {
-			this.tooltipContainer.parentNode.removeChild(this.tooltipContainer);
-			delete this.tooltipContainer;
+		if (this.tooltipParent) {
+			this.tooltipParent.parentNode.removeChild(this.tooltipParent);
+			delete this.tooltipParent;
 		}
 	}
 }
@@ -79,9 +82,14 @@ class Tooltip extends Component {
 		}, Number(this.props.delayTime || 0));
 	}
 	render() {
+		const style = {top: `${this.state.top}px`, left: `${this.state.left}px`};
+		if (this.props.useFixedPosition) {
+			style.position = 'fixed';
+		}
+
 		return this.state.waitingForDelayTime
 			? null
-			: <div className={styles.tooltip} style={{top: `${this.state.top}px`, left: `${this.state.left}px`}} ref={el => this.el = el} dangerouslySetInnerHTML={{__html: this.props.html}} />
+			: <div className={styles.tooltip} style={style} ref={el => this.el = el} dangerouslySetInnerHTML={{__html: this.props.html}} />
 	}
 	componentDidUpdate() {
 		const newPosition = this.getPositionStyles();
@@ -106,7 +114,7 @@ class Tooltip extends Component {
 		} else {
 			left = targetEl.offsetLeft;
 		}
-		left = Math.max(0, left);
+		left = Math.max(0, left + this.props.startingLeft);
 
 		let top;
 		if (this.state.showAbove) {
@@ -117,12 +125,14 @@ class Tooltip extends Component {
 			top = targetEl.offsetTop + targetEl.offsetHeight + verticalMargin;
 		}
 
+		top += this.props.startingTop;
+
 		const showAbove = this.state.showAbove || Boolean(this.el && !this.showAbove && this.el.getBoundingClientRect().bottom > window.innerHeight)
 		
 		return {top, left, showAbove};
 	}
 }
 
-const customElement = preactToCustomElement(CpsTooltip, {parentClass: HTMLElement, properties: ['html', 'delayTime']});
+const customElement = preactToCustomElement(CpsTooltip, {parentClass: HTMLElement, properties: ['html', 'delayTime', 'tooltipContainer', 'useFixedPosition']});
 customElements.define('cps-tooltip', customElement);
 export const CprTooltip = customElementToReact({name: 'cps-tooltip'});

--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -19,28 +19,27 @@ class CpsTooltip extends Component {
 	}
 	render() {
 		const offsetParent = $(this.props.customElement).offsetParent()[0];
-		if (!this.tooltipParent && this.state.renderTooltip) {
-			this.tooltipParent = document.createElement('div');
-			this.tooltipParent.classList.add(styles.tooltipContainer);
+		if (!this.preactContainer && this.state.renderTooltip) {
+			this.preactContainer = document.createElement('div');
 			// Put the tooltip element into the nearest positioned ancestor, so that offsetTop works.
-			this.parentElement = this.props.tooltipContainer || offsetParent
-			this.parentElement.appendChild(this.tooltipParent);
+			this.positionedAncestor = this.props.tooltipContainer || offsetParent;
+			this.positionedAncestor.appendChild(this.preactContainer);
 		}
 
 		const startingLeft = this.props.tooltipContainer ? offsetParent.getBoundingClientRect().left : 0;
 		const startingTop = this.props.tooltipContainer ? offsetParent.getBoundingClientRect().top : 0;
 		const props = {...this.props, tooltipShown: this.tooltipShown, startingLeft, startingTop};
 		const thingToRender = this.state.renderTooltip ? h(Tooltip, props) : '';
-		this.preactTooltip = preact.render(thingToRender, this.tooltipParent, this.preactTooltip);
+		this.preactTooltip = preact.render(thingToRender, this.preactContainer, this.preactTooltip);
 
 		// Don't return anything, we don't care about innerHTML of the custom element
 		return <div style={{height: 0, width: 0}} />;
 	}
 	componentWillUnmount() {
 		this.deleteTooltipElement();
-		if (this.parentElement) {
-			preact.render('', this.parentElement, this.tooltipParent);
-			delete this.parentElement;
+		if (this.positionedAncestor) {
+			preact.render('', this.positionedAncestor, this.preactContainer);
+			delete this.positionedAncestor;
 		}
 	}
 	mousedOver = evt => {
@@ -59,9 +58,9 @@ class CpsTooltip extends Component {
 		this.props.customElement.dispatchEvent(new CustomEvent('cps-tooltip:hidden'));
 	}
 	deleteTooltipElement = () => {
-		if (this.tooltipParent) {
-			this.tooltipParent.parentNode.removeChild(this.tooltipParent);
-			delete this.tooltipParent;
+		if (this.preactContainer) {
+			this.preactContainer.parentNode.removeChild(this.preactContainer);
+			delete this.preactContainer;
 		}
 	}
 }

--- a/src/custom-elements/cps-tooltip/cps-tooltip.styles.css
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.styles.css
@@ -10,9 +10,6 @@
 	position: absolute;
 }
 
-.tooltipContainer {
-}
-
 .inlineBlock {
 	display: inline-block;
 }

--- a/src/custom-elements/cps-tooltip/cps-tooltip.test.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.test.js
@@ -117,4 +117,61 @@ describe(`<cps-tooltip />`, () => {
 		});
 		el.dispatchEvent(new CustomEvent('mouseover'));
 	});
+
+	it(`appends the tooltip as a child of the tooltipContainer property if that property exists`, done => {
+		el.html = 'Html!';
+		el.innerHTML = `<div style="height: 10px"></div>`;
+
+		const parentOfEl = document.createElement('div');
+		parentOfEl.style.position = 'absolute';
+		parentOfEl.style.left = '30px';
+		parentOfEl.style.top = '25px';
+
+		const tooltipContainer = document.createElement('div');
+		tooltipContainer.setAttribute('id', 'tooltipContainer1');
+		document.body.appendChild(tooltipContainer);
+
+		el.tooltipContainer = tooltipContainer;
+		el.addEventListener('cps-tooltip:shown', evt => {
+			let node = evt.detail.tooltipEl;
+			let testFailed = true;
+			while (node = node.parentNode) {
+				if (node === tooltipContainer) {
+					testFailed = false;
+					break;
+				}
+			}
+
+			if (testFailed) {
+				fail(`The tooltip element should have been appended as a child of the specified tooltipContainer`);
+			}
+
+			const rect = evt.detail.tooltipEl.getBoundingClientRect();
+			// Even though we're appending the tooltip to a different container, it needs to respect parentOfEl's position
+			const expectedTop = el.getBoundingClientRect().bottom + 8;
+			expect(rect.top).toBeGreaterThan(expectedTop - 2);
+			expect(rect.top).toBeLessThan(expectedTop + 2);
+
+			parentOfEl.parentNode.removeChild(parentOfEl);
+			tooltipContainer.parentNode.removeChild(tooltipContainer);
+
+			done();
+		});
+
+		document.body.appendChild(parentOfEl);
+		parentOfEl.appendChild(el);
+		el.dispatchEvent(new CustomEvent('mouseover'));
+	});
+
+	it(`will make the tooltip element fixed with useFixedPosition property`, done => {
+		el.html = `Html!`;
+		el.useFixedPosition = true;
+		document.body.appendChild(el);
+		el.addEventListener('cps-tooltip:shown', evt => {
+			expect(getComputedStyle(evt.detail.tooltipEl).getPropertyValue('position')).toBe('fixed');
+			done();
+		});
+
+		el.dispatchEvent(new CustomEvent('mouseover'));
+	});
 });


### PR DESCRIPTION
This will pave the way to fix https://canopytax.atlassian.net/browse/CON-115. The tooltips in the primary navbar need to be fixed positioned since the navbar is fixed, but they cannot be inside of the primary navbar container element itself because it has a lower z-index than the secondary nav / contact-menu that is below it. The tooltips need to show over the top of the contact menu, but cannot unless they are in a separate container element.

Here is my proposed solution:
- a `useFixedPosition` boolean property on the custom element. The alternative would maybe be a `tooltipStyles` property that is an object that could be `{position: 'fixed'}`
- an optional `tooltipContainer` property on the custom element.