### PR TITLE
word-wrap: break-word for cps-tooltip

### DIFF
--- a/src/custom-elements/cps-tooltip/cps-tooltip.styles.css
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.styles.css
@@ -8,6 +8,7 @@
 	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.26);
 	z-index: 100000;
 	position: absolute;
+	word-wrap: break-word;
 }
 
 .inlineBlock {


### PR DESCRIPTION
Before fix:
![screen shot 2017-04-07 at 3 09 02 pm](https://cloud.githubusercontent.com/assets/5524384/24820003/2a93d12c-1ba4-11e7-8b96-9b6ab0fe4572.png)

After fix:
![screen shot 2017-04-07 at 3 08 26 pm](https://cloud.githubusercontent.com/assets/5524384/24819974/12c79588-1ba4-11e7-873e-5d685835230d.png)