### PR TITLE
Adding new properties for specifying left and top.

### DIFF
--- a/src/custom-elements/cps-tooltip/Readme.md
+++ b/src/custom-elements/cps-tooltip/Readme.md
@@ -17,6 +17,8 @@ Properties are good for both initial configuration and for all subsequent change
 - `delayTime` (optional): The number of milliseconds to wait before showing the tooltip.
 - `useFixedPosition` (optional): A boolean that determines whether the tooltip should be fixed positioned or not. Defaults to false.
 - `tooltipContainer` (optional): The container DOM element to put the tooltip element in. Defaults to the nearest positioned ancestor of the `<cps-tooltip>` element.
+- `top` (optional): An integer number of pixels to be applied to the tooltip top. Note that tooltip is absolutely positioned.
+- `left` (optional): An integer number of pixels to be applied to the tooltip left. Note that tooltip is absolutely positioned.
 
 ## Attributes
 Attributes are good for initial configuration. If an attribute is changed, the corresponding property will be updated.

--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -126,6 +126,9 @@ class Tooltip extends Component {
 
 		top += this.props.startingTop;
 
+		top = typeof this.props.top === 'number' ? this.props.top : top;
+		left = typeof this.props.left === 'number' ? this.props.left : left;
+
 		const showAbove = this.state.showAbove || Boolean(this.el && !this.showAbove && this.el.getBoundingClientRect().bottom > window.innerHeight)
 		
 		return {top, left, showAbove};
@@ -134,7 +137,7 @@ class Tooltip extends Component {
 
 const customElement = preactToCustomElement(
 	CpsTooltip,
-	{parentClass: HTMLElement, properties: ['html', 'delayTime', 'tooltipContainer', 'useFixedPosition']}
+	{parentClass: HTMLElement, properties: ['html', 'delayTime', 'tooltipContainer', 'useFixedPosition', 'left', 'top']}
 );
 customElements.define('cps-tooltip', customElement);
 export const CprTooltip = customElementToReact({name: 'cps-tooltip'});

--- a/src/custom-elements/cps-tooltip/cps-tooltip.test.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.test.js
@@ -174,4 +174,19 @@ describe(`<cps-tooltip />`, () => {
 
 		el.dispatchEvent(new CustomEvent('mouseover'));
 	});
+
+	it(`let's you specify 'left' and 'top' which are absolute positions`, done => {
+		el.html = `Html!`;
+		el.useFixedPosition = true;
+		el.top = 54;
+		el.left = 88;
+		document.body.appendChild(el);
+		el.addEventListener('cps-tooltip:shown', evt => {
+			expect(evt.detail.tooltipEl.getBoundingClientRect().top).toEqual(54);
+			expect(evt.detail.tooltipEl.getBoundingClientRect().left).toEqual(88);
+			done();
+		});
+
+		el.dispatchEvent(new CustomEvent('mouseover'));
+	});
 });


### PR DESCRIPTION
This is an optional feature that is just if you want to specify exactly where the tooltip shows up, you can.