### PR TITLE
Fix IE11 bug where mouseleave event isn't being fired always

### DIFF
--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -13,7 +13,11 @@ class CpsTooltip extends Component {
 	}
 	componentDidMount() {
 		this.props.customElement.addEventListener('mouseover', throttle(this.mousedOver, 10));
+
+		// I think IE11 has a bug where mouseleave doesn't always get fired for inline styled elements. So we do both mouseout and mouseleave
+		this.props.customElement.addEventListener('mouseleave', throttle(this.mouseLeave, 10));
 		this.props.customElement.addEventListener('mouseout', throttle(this.mouseLeave, 10));
+
 		// Custom elements default to inline, but inline-block is necessary to calculate height/width correctly
 		this.props.customElement.classList.add(styles.inlineBlock)
 	}

--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -13,7 +13,7 @@ class CpsTooltip extends Component {
 	}
 	componentDidMount() {
 		this.props.customElement.addEventListener('mouseover', throttle(this.mousedOver, 10));
-		this.props.customElement.addEventListener('mouseleave', throttle(this.mouseLeave, 10));
+		this.props.customElement.addEventListener('mouseout', throttle(this.mouseLeave, 10));
 		// Custom elements default to inline, but inline-block is necessary to calculate height/width correctly
 		this.props.customElement.classList.add(styles.inlineBlock)
 	}

--- a/src/custom-elements/cps-tooltip/cps-tooltip.test.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.test.js
@@ -29,7 +29,7 @@ describe(`<cps-tooltip />`, () => {
 
 		el.addEventListener('cps-tooltip:shown', () => {
 			shown = true;
-			el.dispatchEvent(new CustomEvent('mouseout'));
+			el.dispatchEvent(new CustomEvent('mouseleave'));
 		});
 		el.addEventListener('cps-tooltip:hidden', () => {
 			if (!shown) {

--- a/src/custom-elements/cps-tooltip/cps-tooltip.test.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.test.js
@@ -29,7 +29,7 @@ describe(`<cps-tooltip />`, () => {
 
 		el.addEventListener('cps-tooltip:shown', () => {
 			shown = true;
-			el.dispatchEvent(new CustomEvent('mouseleave'));
+			el.dispatchEvent(new CustomEvent('mouseout'));
 		});
 		el.addEventListener('cps-tooltip:hidden', () => {
 			if (!shown) {
@@ -49,6 +49,21 @@ describe(`<cps-tooltip />`, () => {
 		el.addEventListener('cps-tooltip:shown', evt => {
 			expect(evt.detail.tooltipEl.innerHTML).toEqual(html);
 			el.dispatchEvent(new CustomEvent('mouseleave'));
+		});
+
+		el.addEventListener('cps-tooltip:hidden', done);
+
+		el.dispatchEvent(new CustomEvent('mouseover'));
+	});
+
+	it(`hides the tooltip even if mouseleave is never fired (but mouseover _is_ fired)`, done => {
+		const html = `<i>Show this in the tooltip</i>`
+		el.html = html;
+		document.body.appendChild(el);
+
+		el.addEventListener('cps-tooltip:shown', evt => {
+			expect(evt.detail.tooltipEl.innerHTML).toEqual(html);
+			el.dispatchEvent(new CustomEvent('mouseout'));
 		});
 
 		el.addEventListener('cps-tooltip:hidden', done);


### PR DESCRIPTION
I'm not sure exactly the conditions which cause the `mouseleave` event to not be fired, but apparently there exists such a condition. In that case, the `mouseout` event is still fired though. So I just added both event handlers so that the tooltip always works in all weird IE situations.