### PR TITLE
Fix bug where custom elements don't re-render properly

### DIFF
--- a/.fontcustom-manifest.json
+++ b/.fontcustom-manifest.json
@@ -1,7 +1,7 @@
 {
   "checksum": {
-    "previous": "65650da80411b2cbadb36c425b50f3a37573095925a57eb0d46c4848ecfbc3f1",
-    "current": "65650da80411b2cbadb36c425b50f3a37573095925a57eb0d46c4848ecfbc3f1"
+    "previous": "1cea44b5c48c6b7d0b8f500d87cf05faaa2b909fcf73838c1f1327cccd011e5d",
+    "current": "1cea44b5c48c6b7d0b8f500d87cf05faaa2b909fcf73838c1f1327cccd011e5d"
   },
   "fonts": [
     "fonts/canopy-icons.ttf",

--- a/src/custom-elements/cps-button/cps-button.test.js
+++ b/src/custom-elements/cps-button/cps-button.test.js
@@ -22,7 +22,7 @@ describe(`<button is="cps-button" />`, () => {
 		expect(el instanceof customElements.get('cps-button')).toBe(true);
 	});
 
-	it(`respects the actionType property values of 'primary' and 'secondary'`, (done) => {
+	it(`respects the actionType property values of 'primary' and 'secondary'`, () => {
 		// Set the actionType before even appending to doc
 		el.actionType = 'primary';
 		document.body.appendChild(el);
@@ -30,18 +30,10 @@ describe(`<button is="cps-button" />`, () => {
 		expect(getComputedStyle(el).backgroundColor).toEqual('rgb(0, 191, 75)');
 
 		el.actionType = 'secondary';
+		expect(getComputedStyle(el).backgroundColor).toEqual('rgb(244, 244, 244)');
 
-		setTimeout(() => {
-			expect(getComputedStyle(el).backgroundColor).toEqual('rgb(244, 244, 244)');
-
-			el.actionType = 'primary';
-
-			setTimeout(() => {
-				expect(getComputedStyle(el).backgroundColor).toEqual('rgb(0, 191, 75)');
-				done();
-			});
-		});
-
+		el.actionType = 'primary';
+		expect(getComputedStyle(el).backgroundColor).toEqual('rgb(0, 191, 75)');
 	});
 
 	it(`respects the actionType property value for 'flat'`, () => {
@@ -53,24 +45,19 @@ describe(`<button is="cps-button" />`, () => {
 		expect(getComputedStyle(el).color).toEqual('rgb(0, 191, 75)');
 	});
 
-	it(`respects the showLoader property`, done => {
+	it(`respects the showLoader property`, () => {
 		el.textContent = 'Button text'
 		document.body.appendChild(el);
 
 		expect(el.querySelector('.cps-loader')).toBeFalsy();
 
 		el.showLoader = true;
-		setTimeout(() => {
-			expect(el.querySelector('.cps-loader')).toBeTruthy();
-			expect(el.textContent).toBe('');
-			el.showLoader = false;
+		expect(el.querySelector('.cps-loader')).toBeTruthy();
+		expect(el.textContent).toBe('');
+		el.showLoader = false;
 
-			setTimeout(() => {
-				expect(el.querySelector('.cps-loader')).toBeFalsy();
-				expect(el.textContent).toBe('Button text'); // Restores the text from before loader was activated
-				done();
-			});
-		});
+		expect(el.querySelector('.cps-loader')).toBeFalsy();
+		expect(el.textContent).toBe('Button text'); // Restores the text from before loader was activated
 	});
 
 	it(`respects the disableOnClick property`, done => {

--- a/src/custom-elements/cps-tooltip/cps-tooltip.test.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.test.js
@@ -161,10 +161,8 @@ describe(`<cps-tooltip />`, () => {
 			done();
 		});
 
-		setTimeout(() => {
-			el.tooltipContainer = tooltipContainer;
-			el.dispatchEvent(new CustomEvent('mouseover'));
-		});
+		el.tooltipContainer = tooltipContainer;
+		el.dispatchEvent(new CustomEvent('mouseover'));
 	});
 
 	it(`will make the tooltip element fixed with useFixedPosition property`, done => {


### PR DESCRIPTION
When the preact root node doesn't have a parent node, to a complete
re-render without a virtual DOM diff