### PR TITLE
Maintain width and height of button when showing the loader.

### DIFF
--- a/src/custom-elements/cps-button/cps-button.js
+++ b/src/custom-elements/cps-button/cps-button.js
@@ -4,8 +4,10 @@ import {customElementToReact} from '../react-interop.js';
 import {preactToCustomElement} from '../preact-to-custom-element.js';
 
 class CpsButton extends Component {
-	static state = {
+	state = {
 		disabled: false,
+		loaderWidth: null,
+		loaderHeight: null,
 	}
 	componentDidMount() {
 		// Used for disableOnClick
@@ -29,6 +31,9 @@ class CpsButton extends Component {
 
 		// Only return something if we want to completely overwrite the innerHTML
 		if (this.props.showLoader) {
+			if (!this.props.customElement.querySelector('.cps-loader')) {
+				this.prepareElementForLoader();
+			}
 			return (
 				<span className={`cps-loader ${styles.loader} ${this.props.customElement.disabled ? styles.disabledWithLoader : ''}`}>
 					<span />
@@ -49,13 +54,29 @@ class CpsButton extends Component {
 		 * remove the text nodes in order to achieve the same effect.
 		 */
 		if (!oldProps.showLoader && nextProps.showLoader) {
+			this.prepareElementForLoader();
 			this.textNodes = Array.prototype.filter.call(nextProps.customElement.childNodes, childNode => childNode.nodeType === 3);
 			Array.prototype.forEach.call(this.textNodes, textNode => textNode.parentNode.removeChild(textNode));
 		}
 
 		if (oldProps.showLoader && !nextProps.showLoader) {
-			Array.prototype.forEach.call(this.textNodes, textNode => nextProps.customElement.appendChild(textNode));
-			delete this.textNodes;
+			this.loaderIsGone();
+		}
+	}
+	prepareElementForLoader = () => {
+		this.widthBeforeLoader = this.props.customElement.style.clientWidth;
+		this.heightBeforeLoader = this.props.customElement.style.clientHeight;
+
+		this.props.customElement.style.width = this.props.customElement.clientWidth + "px";
+		this.props.customElement.style.height = this.props.customElement.clientHeight + "px";
+	}
+	loaderIsGone = () => {
+		Array.prototype.forEach.call(this.textNodes, textNode => nextProps.customElement.appendChild(textNode));
+		delete this.textNodes;
+
+		if (this.widthBeforeLoader) {
+			this.props.customElement.style.width = this.widthBeforeLoader;
+			this.props.customElement.style.height = this.heightBeforeLoader;
 		}
 	}
 }

--- a/src/custom-elements/cps-button/cps-button.js
+++ b/src/custom-elements/cps-button/cps-button.js
@@ -60,7 +60,7 @@ class CpsButton extends Component {
 		}
 
 		if (oldProps.showLoader && !nextProps.showLoader) {
-			this.loaderIsGone();
+			this.loaderIsGone(nextProps);
 		}
 	}
 	prepareElementForLoader = () => {
@@ -70,8 +70,8 @@ class CpsButton extends Component {
 		this.props.customElement.style.width = this.props.customElement.clientWidth + "px";
 		this.props.customElement.style.height = this.props.customElement.clientHeight + "px";
 	}
-	loaderIsGone = () => {
-		Array.prototype.forEach.call(this.textNodes, textNode => nextProps.customElement.appendChild(textNode));
+	loaderIsGone = props => {
+		Array.prototype.forEach.call(this.textNodes, textNode => props.customElement.appendChild(textNode));
 		delete this.textNodes;
 
 		if (this.widthBeforeLoader) {

--- a/src/custom-elements/cps-button/cps-button.js
+++ b/src/custom-elements/cps-button/cps-button.js
@@ -78,6 +78,9 @@ class CpsButton extends Component {
 			this.props.customElement.style.width = this.widthBeforeLoader;
 			this.props.customElement.style.height = this.heightBeforeLoader;
 		}
+
+		delete this.widthBeforeLoader;
+		delete this.heightBeforeLoader;
 	}
 }
 

--- a/src/custom-elements/cps-button/cps-button.styles.css
+++ b/src/custom-elements/cps-button/cps-button.styles.css
@@ -61,6 +61,10 @@
 	background-color: #e9e9e9;
 }
 
+.secondary .loader span {
+	background-color: #afafaf;
+}
+
 .button :global(.cps-icon) {
 	float: left;
 	padding-right: 4px;

--- a/src/custom-elements/cps-button/cps-button.test.js
+++ b/src/custom-elements/cps-button/cps-button.test.js
@@ -80,4 +80,17 @@ describe(`<button is="cps-button" />`, () => {
 
 		expect(el.getBoundingClientRect().height).toEqual(48);
 	});
+
+	it(`doesn't change the width of a button when the loader shows after initially not showing`, done => {
+		el.textContent = 'a pretty wide button';
+		document.body.appendChild(el);
+
+		setTimeout(() => {
+			const originalWidth = el.clientWidth;
+			el.showLoader = true;
+			expect(el.querySelector('.cps-loader'));
+			expect(el.clientWidth).toEqual(originalWidth);
+			done();
+		}, 50);
+	});
 });


### PR DESCRIPTION
The cps-button custom element currently changes width when you do `buttonEl.showLoader = true`. Instead, I think it would be better if it maintained its width. Example:

Button before showLoader is set:
![screen shot 2017-04-28 at 2 47 16 pm](https://cloud.githubusercontent.com/assets/5524384/25546740/99da07c6-2c21-11e7-868d-619ec6975c92.png)

Button after showLoader is set (without my fix):
![screen shot 2017-04-28 at 2 47 37 pm](https://cloud.githubusercontent.com/assets/5524384/25546747/a473b088-2c21-11e7-8c40-20f018355957.png)

Button after showLoader is set (with my fix):
![screen shot 2017-04-28 at 2 49 16 pm](https://cloud.githubusercontent.com/assets/5524384/25546790/deaace62-2c21-11e7-8905-17cecd71e8cf.png)
