### PR TITLE
Change the width of the loader component to make it easier to center

### DIFF
--- a/src/custom-elements/cps-loader/cps-loader.helper.js
+++ b/src/custom-elements/cps-loader/cps-loader.helper.js
@@ -4,28 +4,30 @@ export function determineDotWidth(props){
 		let size = parseInt(props.dotSize);
 		if(isNaN(size)){
 			size = props.page ? 42 : 8;
-		} 
+		}
 		return size;
 }
 
 export function makeDots(props){
     let dots = [];
     for(let i= 0; i < 3; i++){
-        dots.push(makeDot(props));
+        dots.push(makeDot(props, i === 2));
     }
     return dots;
 }
 
-export function makeDot(props){
+export function makeDot(props, last){
     const size = determineDotWidth(props);
+		const styles = {
+			backgroundColor: props.color || '#e0e0e0',
+			width: size,
+			height: size,
+			marginLeft: size,
+		};
+
+		if (last) styles.marginRight = size;
+
     return (
-        <span style={
-            {
-                backgroundColor: props.color || '#e0e0e0',
-                width: size,
-                height: size,
-                marginLeft: size,
-            }
-        } />
+        <span style={styles} />
     )
 }


### PR DESCRIPTION
This changes the width of the loader component so that it is easier to center. For example:

![image](https://user-images.githubusercontent.com/1566869/28390052-b5207b8c-6c95-11e7-8ea5-98cd38e08c22.png)

now looks like:

![image](https://user-images.githubusercontent.com/1566869/28390070-c9fbd1fa-6c95-11e7-8586-a288bb841f24.png)

with default flexbox center positioning.