### PR TITLE
If the tooltip is already rendered, don't render again.

### DIFF
--- a/src/custom-elements/cps-tooltip/cps-tooltip.js
+++ b/src/custom-elements/cps-tooltip/cps-tooltip.js
@@ -68,7 +68,9 @@ class TooltipTargetElement extends Component {
 	mousedOver = evt => {
 		clearTimeout(this.hideTooltipTimeout);
 		delete this.hideTooltipTimeout;
-		this.setState({renderTooltip: true});
+
+		//don't force a rerender, which creates duplicate tooltips, if we already have one
+		if(!this.state.renderTooltip) this.setState({renderTooltip: true});
 	}
 	mouseLeave = evt => {
 		const timeToWait = this.props.allowInteraction ? 500 : 0;


### PR DESCRIPTION
This can happen when the Tooltip custom element has multiple children elements, and thanks to the magic of event bubbling you could create an infinite amount of duplicated tooltips.

(note that the render function creates a new element every time, so if we keep on calling render then it will keep creating new elements)