### PR TITLE
Fixes for Chrome to recognize that buttons need letter spacing, too.

### DIFF
--- a/src/custom-elements/cps-button/cps-button.js
+++ b/src/custom-elements/cps-button/cps-button.js
@@ -24,6 +24,7 @@ class CpsButton extends Component {
 		toggleClass(this.props.customElement, styles.secondary, this.props.actionType === 'secondary');
 		toggleClass(this.props.customElement, styles.flat, this.props.actionType === 'flat');
 		toggleClass(this.props.customElement, styles.phat, !!this.props.phat);
+		this.props.customElement.classList.add(styles.buttonLetterSpacing);
 
 		if (this.state.disabled) {
 			this.props.customElement.disabled = this.state.disabled;

--- a/src/custom-elements/cps-button/cps-button.styles.css
+++ b/src/custom-elements/cps-button/cps-button.styles.css
@@ -177,3 +177,7 @@ button.phat {
 	height: 48px;
 	padding: 0 28px;
 }
+
+.buttonLetterSpacing {
+	letter-spacing: inherit;
+}


### PR DESCRIPTION
Otherwise Chrome uses the default user agent setting for letter spacing, which is different than what we've set on body.