### PR TITLE
Reduced padding on calendar month name.

### DIFF
--- a/src/custom-elements/cps-datepicker/cps-datepicker.styles.css
+++ b/src/custom-elements/cps-datepicker/cps-datepicker.styles.css
@@ -32,7 +32,7 @@
 }
 
 .header {
-	justify-content: space-around;
+	justify-content: space-between;
 	align-items: center;
 	display: flex
 }
@@ -47,7 +47,7 @@
 }
 
 .headerDisplay {
-	padding: 4px 24px;
+	padding: 4px 12px;
 	cursor: pointer;
 	border-radius: 15px;
 	text-align: center;

--- a/src/custom-elements/cps-datepicker/days.component.js
+++ b/src/custom-elements/cps-datepicker/days.component.js
@@ -3,7 +3,7 @@ import styles from './cps-datepicker.styles.css';
 import moment from 'moment';
 import { range, chunk, partial } from 'lodash';
 
-const days = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+const days = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
 export default class Days extends Component {
 	render() {


### PR DESCRIPTION
Changed to space-between so that next/previous month arrows are consistently in the same spot, regardless of the length of the month name.

Changed the days of the week to be just one letter instead of two.